### PR TITLE
Add PHP short-hand echo example to echoed-requests test cases

### DIFF
--- a/php/lang/security/injection/echoed-request.php
+++ b/php/lang/security/injection/echoed-request.php
@@ -84,4 +84,10 @@ function doOK7() {
     echo $safevar;
 }
 
+?>
 
+<? // ruleid: echoed-request ?>
+<?= $_GET['payload'] ?>
+
+<? // ok: echoed-request ?>
+<?= htmlentities($_GET['payload']) ?>


### PR DESCRIPTION
Proves that `<?= ?>` is a captured as a sink for xss in PHP